### PR TITLE
correct the command to next cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next eslint ."
+    "lint": "next lint ."
   },
   "dependencies": {
     "next": "12.2.3",


### PR DESCRIPTION
As per the [docs](https://nextjs.org/docs/basic-features/eslint) the command is `next lint`. Under the hood the `eslint` binary is called. But the command via the Next.js CLI is `lint`.